### PR TITLE
細々としたリファクタリング

### DIFF
--- a/app/templates.py
+++ b/app/templates.py
@@ -1,6 +1,8 @@
+import os
 from datetime import datetime
+from functools import wraps
 from pathlib import Path
-from typing import Any, Callable, Concatenate, ParamSpec
+from typing import Any, Callable, Protocol
 
 import jinja2
 from fastapi import Request
@@ -31,33 +33,36 @@ def _url_for(context: dict[str, Any], name: str, /, **path_params: Any) -> URL:
 env.globals.setdefault("url_for", _url_for)
 
 
-def load_macro(
-    request: Request, name: str, macro_name: str | None = None
-) -> jinja2.runtime.Macro:
-    """If the `macro_name` is not specified, this method assumes that the input
-    template defines the macro named the same as the stem of `name`. Note that
-    `name` with hyphen characters will be converted to underscores to follow the
-    convetion of common HTML file names.
-    """
-    template = env.get_template(name, globals={"request": request, **globals})
-    if macro_name is None:
-        macro_name = Path(name).stem.replace("-", "_")
+def load_macro(template: jinja2.Template, macro_name: str) -> jinja2.runtime.Macro:
     macro = getattr(template.module, macro_name)
     if not isinstance(macro, jinja2.runtime.Macro):
         raise Exception(f"{macro} is not a jinja2.runtime.Macro instance")
     return macro
 
 
-P = ParamSpec("P")
+def hyphen_path_to_underscore_stem(path: str | os.PathLike[str]) -> str:
+    return Path(path).stem.replace("-", "_")
 
 
-def macro_template(
-    name: str,
-    macro_name: str | None = None,
-) -> Callable[[Callable[P, None]], Callable[Concatenate[Request, P], str]]:
-    def type_signature(_: Callable[P, None]) -> Callable[Concatenate[Request, P], str]:
-        def with_request(request: Request, *args: P.args, **kwargs: P.kwargs) -> str:
-            return load_macro(request, name, macro_name)(*args, **kwargs)
+class _MacroArgHints[**P](Protocol):
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> None: ...
+
+
+class _RenderMacroWithRequest[**P](Protocol):
+    def __call__(self, request: Request, *args: P.args, **kwargs: P.kwargs) -> str: ...
+
+
+def macro_template[**P](
+    name: str, macro_name: str | None = None
+) -> Callable[[_MacroArgHints[P]], _RenderMacroWithRequest[P]]:
+    if macro_name is None:
+        macro_name = hyphen_path_to_underscore_stem(name)
+
+    def type_signature(fn: _MacroArgHints[P]) -> _RenderMacroWithRequest[P]:
+        @wraps(fn)
+        def with_request(request, *args: P.args, **kwargs: P.kwargs) -> str:
+            template = env.get_template(name, globals={"request": request, **globals})
+            return load_macro(template, macro_name)(*args, **kwargs)
 
         return with_request
 

--- a/app/test_templates.py
+++ b/app/test_templates.py
@@ -1,0 +1,85 @@
+import ast
+from pathlib import Path
+from typing import Any, Generator
+
+import jinja2
+from inline_snapshot import snapshot
+from jinja2.ext import debug
+
+from . import templates
+
+loader = jinja2.FileSystemLoader(templates.TEMPLATES_DIR)
+env = jinja2.Environment(
+    extensions=[debug],
+    undefined=jinja2.StrictUndefined,
+    autoescape=True,
+    loader=loader,
+)
+debug_global = {"DEBUG": True}
+
+
+def test_hyphen_path_to_underscore_stem_should_extract_stem():
+    inputs = ["index", "/index", "/index.html", "/accounts/4/index.html"]
+    outputs = [templates.hyphen_path_to_underscore_stem(input) for input in inputs]
+    assert outputs == snapshot(["index", "index", "index", "index"])
+
+
+def test_hyphen_path_to_underscore_stem_should_convert_hyphens_to_underscores():
+    inputs = [
+        "/sold-items.html",
+        "/accounts/4/privacy-settings.html",
+        "/system-accounts/4/privacy-settings.html",
+    ]
+    outputs = [templates.hyphen_path_to_underscore_stem(input) for input in inputs]
+    assert outputs == snapshot(["sold_items", "privacy_settings", "privacy_settings"])
+
+
+def test_templates_and_corresponding_macros_have_the_same_name():
+    for name in loader.list_templates():
+        module = env.get_template(name, globals=debug_global.copy()).module
+        expected_macro_name = templates.hyphen_path_to_underscore_stem(name)
+        err_msg = f'{name} has no macro named "{expected_macro_name}"'
+        assert expected_macro_name in dir(module), err_msg
+        macro = getattr(module, expected_macro_name)
+        assert isinstance(macro, jinja2.runtime.Macro)
+        assert expected_macro_name == macro.name
+
+
+def test_macro_argument_names_and_function_parameter_names_match():
+    def func_defs(
+        tree: ast.Module,
+    ) -> Generator[ast.FunctionDef | ast.AsyncFunctionDef, Any, None]:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) or isinstance(
+                node, ast.AsyncFunctionDef
+            ):
+                yield node
+
+    def macro_template_decorated_func_defs(
+        tree: ast.Module,
+    ) -> Generator[tuple[list[str], ast.FunctionDef | ast.AsyncFunctionDef], Any, None]:
+        for func_def in func_defs(tree):
+            for dec in func_def.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+
+                func = dec.func
+                if (
+                    isinstance(func, ast.Name)
+                    and func.id == templates.macro_template.__name__
+                ):
+                    assert isinstance(dec.args[0], ast.Constant)
+                    assert isinstance(dec.args[0].value, str)
+                    name = dec.args[0].value
+                    module = env.get_template(name, globals=debug_global.copy()).module
+                    macro_name = templates.hyphen_path_to_underscore_stem(name)
+                    macro: jinja2.runtime.Macro = getattr(module, macro_name)
+                    yield macro.arguments, func_def
+
+    tree = ast.parse(Path(templates.__file__).read_bytes())
+    for macro_args, func_def in macro_template_decorated_func_defs(tree):
+        # print(f"\n[{func_def.name}(...)]")
+        for i, (macro_arg, func_arg) in enumerate(zip(macro_args, func_def.args.args)):
+            # print(i, (macro_arg, func_arg.arg))
+            err_msg = f"The macro argument and function parameter do not match at {i}: {macro_arg} != {func_arg.arg}"
+            assert macro_arg == func_arg.arg, err_msg

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -98,33 +98,7 @@ murchace は htmx、Tailwind CSS、FastAPI で構築されています。
 クライアントの要望に応じて、FastAPI サーバで注文情報を管理します。
 UI は基本 HTML で記述します。
 
-## パス操作一覧
-
-### `/`
-
-ホーム。
-他リソースへのハイパーリンクを列挙する。
-
-### `/orders`
-
-新規注文のリソース。
-`/orders/{session_id}` と `/orders/{session_id}/item/` に対する操作で注文セッションを管理する。
-
-### `/placements`
-
-`/orders` で確定した注文に関するリソース。
-提供待ち、受け渡し済みどちらも確定注文に含まれる。
-
-### `/products` (未実装)
-
-商品に関するリソース。
-商品の追加・削除、名前・画像・値段・在庫の変更が可能。
-
-### `/settings` (未実装)
-
-システムの詳細な設定に関するリソース。
-
-## 参考リンク
+### 参考リンク
 
 - FastAPI: https://fastapi.tiangolo.com/ja/ (日本語)
 - FastAPI: https://fastapi.tiangolo.com/ (English)
@@ -135,7 +109,7 @@ UI は基本 HTML で記述します。
 - 非同期データベースライブラリ: https://www.encode.io/databases/ (English)
 - SQL のドメイン固有言語: https://docs.sqlalchemy.org/en/20/core/ (English)
 
-### VSCode の拡張機能一覧
+## VSCode の拡張機能一覧
 
 - [charliermarsh.ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff): 高速な Python LSP
 - [ms-pyright.pyright](https://marketplace.visualstudio.com/items?itemName=ms-pyright.pyright): Python の型チェックに特化した LSP (VSCode の場合は Pylance でも可)


### PR DESCRIPTION
- `@macro_template` デコレータの型ヒントをちょっと読みやすくした
- app/templates.pyのテストケースを追加した
- すぐに情報が古くなって書き換えが頻繁に行われると思われるドキュメント部分を削除