### PR TITLE
マルチプラットフォームビルドの修正

### DIFF
--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -6,15 +6,16 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/devcontainer.yaml'
       - '.devcontainer/Dockerfile'
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: tut-cc/murchace-dev
+  IMAGE_NAME: ghcr.io/tut-cc/murchace-dev
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-24.04
     if: github.repository == 'tut-cc/murchace'
     permissions:
       contents: read
@@ -45,7 +46,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -59,6 +60,57 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: .
           file: ./.devcontainer/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    if: ${{ github.ref_name == 'test' }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -80,7 +80,6 @@ jobs:
   merge:
     runs-on: ubuntu-24.04
     needs: build
-    if: ${{ github.ref_name == 'test' }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/prodcontainer.yaml
+++ b/.github/workflows/prodcontainer.yaml
@@ -7,18 +7,19 @@ on:
       - main
     paths-ignore:
       - '.devcontainer/**'
-      - '.github/**'
+      - '.github/workflows/devcontainer.yaml'
+      - '.github/workflows/CI.yaml'
       - 'README.md'
       - 'LICENSE'
-      - 'gitingore'
+      - '.gitignore'
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: tut-cc/murchace
+  IMAGE_NAME: ghcr.io/tut-cc/murchace
 
 jobs:
-  build-and-push-image:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-24.04
     if: github.repository == 'tut-cc/murchace'
     permissions:
       contents: read
@@ -48,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -56,12 +57,64 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push container image
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           platforms: ${{ matrix.platform }}
           context: .
           file: Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-24.04
+    needs: build
+    if: ${{ github.ref_name == 'test' }}
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/prodcontainer.yaml
+++ b/.github/workflows/prodcontainer.yaml
@@ -84,7 +84,6 @@ jobs:
   merge:
     runs-on: ubuntu-24.04
     needs: build
-    if: ${{ github.ref_name == 'test' }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4


### PR DESCRIPTION
並列ワークフローでビルドしてプッシュする際、先にビルドが終了する`linux/amd64`が破棄されてしまっていた。  
`merge`ワークフローを追加することで`linux/amd64`及び`linux/arm64`の両方をプッシュできるようにした。